### PR TITLE
Fixed mod folder not opening on java 25 with certain OS configurations

### DIFF
--- a/src/main/java/com/cleanroommc/catalogue/client/screen/CatalogueModListScreen.java
+++ b/src/main/java/com/cleanroommc/catalogue/client/screen/CatalogueModListScreen.java
@@ -425,44 +425,6 @@ public class CatalogueModListScreen extends GuiScreen implements DropdownMenuHan
         this.searchTextField.updateCursorCounter();
     }
 
-    // From net.minecraft.client.gui.GuiScreenResourcePacks. Works properly with java 25.
-    private void openFolder(File folder) {
-        String absolutePath = folder.getAbsolutePath();
-
-        if (Util.getOSType() == Util.EnumOS.OSX) {
-            try {
-                Runtime.getRuntime().exec(new String[] {"/usr/bin/open", absolutePath});
-                return;
-            } catch (IOException ioexception) {
-                CatalogueConstants.LOG.error("Problem opening mods folder", ioexception);
-            }
-        } else if (Util.getOSType() == Util.EnumOS.WINDOWS) {
-            String openCommand = String.format("cmd.exe /C start \"Open file\" \"%s\"", new Object[] {absolutePath});
-            try {
-                Runtime.getRuntime().exec(openCommand);
-                return;
-            } catch (IOException ioexception) {
-                CatalogueConstants.LOG.error("Problem opening mods folder", ioexception);
-            }
-        }
-
-        boolean awtDesktopFailed = false;
-
-        try {
-            Class oclass = Class.forName("java.awt.Desktop");
-            Object object = oclass.getMethod("getDesktop", new Class[0]).invoke(null, new Object[0]);
-            oclass.getMethod("browse", new Class[] {URI.class}).invoke(object, new Object[] {folder.toURI()});
-        } catch (Throwable throwable) {
-            CatalogueConstants.LOG.error("Problem opening mods folder", throwable);
-            awtDesktopFailed = true;
-        }
-
-        if (awtDesktopFailed) {
-            CatalogueConstants.LOG.info("Opening via system class!");
-            Sys.openURL("file://" + absolutePath);
-        }
-    }
-
     /**
      * Draws everything considered left of the screen; title, search bar and mod list.
      *
@@ -1356,6 +1318,46 @@ public class CatalogueModListScreen extends GuiScreen implements DropdownMenuHan
         }
     }
 
+    /// {@link net.minecraft.client.gui.GuiScreenResourcePacks#actionPerformed(GuiButton)}
+    /// Works properly with java 25.
+    @SuppressWarnings("JavadocReference")
+    private static void openFolder(File folder) {
+        String absolutePath = folder.getAbsolutePath();
+
+        if (Util.getOSType() == Util.EnumOS.OSX) {
+            try {
+                Runtime.getRuntime().exec(new String[] {"/usr/bin/open", absolutePath});
+                return;
+            } catch (IOException ioexception) {
+                CatalogueConstants.LOG.error("Problem opening mods folder", ioexception);
+            }
+        } else if (Util.getOSType() == Util.EnumOS.WINDOWS) {
+            String openCommand = String.format("cmd.exe /C start \"Open file\" \"%s\"", absolutePath);
+            try {
+                Runtime.getRuntime().exec(openCommand);
+                return;
+            } catch (IOException ioexception) {
+                CatalogueConstants.LOG.error("Problem opening mods folder", ioexception);
+            }
+        }
+
+        boolean awtDesktopFailed = false;
+
+        try {
+            Class<?> oclass = Class.forName("java.awt.Desktop");
+            Object object = oclass.getMethod("getDesktop", new Class[0]).invoke(null);
+            oclass.getMethod("browse", new Class[] {URI.class}).invoke(object, folder.toURI());
+        } catch (Throwable throwable) {
+            CatalogueConstants.LOG.error("Problem opening mods folder", throwable);
+            awtDesktopFailed = true;
+        }
+
+        if (awtDesktopFailed) {
+            CatalogueConstants.LOG.info("Opening via system class!");
+            Sys.openURL("file://" + absolutePath);
+        }
+    }
+
     /**
      * Creates a confirmation screen to open a link
      *
@@ -1365,8 +1367,7 @@ public class CatalogueModListScreen extends GuiScreen implements DropdownMenuHan
         if (url == null) return;
         try {
             URI uri = new URI(url);
-            if (!GuiChat.field_152175_f.contains(
-                    uri.getScheme().toLowerCase())) {
+            if (!GuiChat.field_152175_f.contains(uri.getScheme().toLowerCase())) {
                 throw new URISyntaxException(url, "Unsupported protocol: " + uri.getScheme().toLowerCase());
             }
             if (this.mc.gameSettings.chatLinksPrompt) {

--- a/src/main/java/com/cleanroommc/catalogue/client/screen/CatalogueModListScreen.java
+++ b/src/main/java/com/cleanroommc/catalogue/client/screen/CatalogueModListScreen.java
@@ -31,9 +31,11 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.Util;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.apache.commons.lang3.tuple.Pair;
+import org.lwjgl.Sys;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
@@ -216,15 +218,7 @@ public class CatalogueModListScreen extends GuiScreen implements DropdownMenuHan
     public void actionPerformed(@Nonnull GuiButton button) {
         switch (button.id) {
             case 1 -> this.mc.displayGuiScreen(this.parentScreen);
-            case 2 -> {
-                try {
-                    Class<?> oclass = Class.forName("java.awt.Desktop");
-                    Object object = oclass.getMethod("getDesktop", new Class[0]).invoke(null);
-                    oclass.getMethod("open", File.class).invoke(object, ClientServices.PLATFORM.getModDirectory());
-                } catch (Exception e) {
-                    CatalogueConstants.LOG.error("Problem opening mods folder", e);
-                }
-            }
+            case 2 -> openFolder(ClientServices.PLATFORM.getModDirectory());
             case 3 -> this.selectedModData.openConfigScreen(this.mc, this);
             case 4 -> this.openLink(this.selectedModData.getHomepage());
             case 5 -> this.openLink(this.selectedModData.getIssueTracker());
@@ -429,6 +423,44 @@ public class CatalogueModListScreen extends GuiScreen implements DropdownMenuHan
     public void updateScreen() {
         super.updateScreen();
         this.searchTextField.updateCursorCounter();
+    }
+
+    // From net.minecraft.client.gui.GuiScreenResourcePacks. Works properly with java 25.
+    private void openFolder(File folder) {
+        String absolutePath = folder.getAbsolutePath();
+
+        if (Util.getOSType() == Util.EnumOS.OSX) {
+            try {
+                Runtime.getRuntime().exec(new String[] {"/usr/bin/open", absolutePath});
+                return;
+            } catch (IOException ioexception) {
+                CatalogueConstants.LOG.error("Problem opening mods folder", ioexception);
+            }
+        } else if (Util.getOSType() == Util.EnumOS.WINDOWS) {
+            String openCommand = String.format("cmd.exe /C start \"Open file\" \"%s\"", new Object[] {absolutePath});
+            try {
+                Runtime.getRuntime().exec(openCommand);
+                return;
+            } catch (IOException ioexception) {
+                CatalogueConstants.LOG.error("Problem opening mods folder", ioexception);
+            }
+        }
+
+        boolean awtDesktopFailed = false;
+
+        try {
+            Class oclass = Class.forName("java.awt.Desktop");
+            Object object = oclass.getMethod("getDesktop", new Class[0]).invoke(null, new Object[0]);
+            oclass.getMethod("browse", new Class[] {URI.class}).invoke(object, new Object[] {folder.toURI()});
+        } catch (Throwable throwable) {
+            CatalogueConstants.LOG.error("Problem opening mods folder", throwable);
+            awtDesktopFailed = true;
+        }
+
+        if (awtDesktopFailed) {
+            CatalogueConstants.LOG.info("Opening via system class!");
+            Sys.openURL("file://" + absolutePath);
+        }
     }
 
     /**


### PR DESCRIPTION
Using code from `net.minecraft.client.gui.GuiScreenResourcePacks` to handle more OS configurations for opening files.
TL:DR on Macos the open mods folder works with java 8, but not lwjgl3ify and java 25.